### PR TITLE
remove log4j1 dependency and set junit scope to test

### DIFF
--- a/org.afplib/pom.xml
+++ b/org.afplib/pom.xml
@@ -129,11 +129,6 @@
 			<version>1.7.7</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.7</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.3.2</version>
@@ -157,6 +152,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Hi Yan,
I made a small pull request, as I start using afplib. I removed the slf4j-log4j1 dependency, as log4j 1 is pretty deprecated, and for a library it should be enough to depend on slf api. 
Also, I set JUnit Scope to test.
With these changes, I'd be able to use afplib without any exclusions.

Thanks,
Sören