### PR TITLE
fix javadoc plugin config  to build with jdk >=9

### DIFF
--- a/org.afplib/pom.xml
+++ b/org.afplib/pom.xml
@@ -82,6 +82,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
+				<configuration>
+					<source>7</source>
+				</configuration>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>

--- a/org.afplib/pom.xml
+++ b/org.afplib/pom.xml
@@ -83,7 +83,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.9.1</version>
 				<configuration>
-					<source>7</source>
+					<detectJavaApiLink>false</detectJavaApiLink>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
when building with open-jdk-11 I'll get the error
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.

alternative would be to set
<source>7</source>
configuration to create links to oracle 7 API Docs