### PR TITLE
Replaced IOException by new AFPFormatException 

### DIFF
--- a/org.afplib/src/main/java/org/afplib/io/AFPFormatException.java
+++ b/org.afplib/src/main/java/org/afplib/io/AFPFormatException.java
@@ -1,0 +1,23 @@
+package org.afplib.io;
+
+import java.io.IOException;
+
+public class AFPFormatException extends IOException {
+
+	public AFPFormatException() {
+		super();
+	}
+
+	public AFPFormatException(String message) {
+		super(message);
+	}
+
+	public AFPFormatException(Throwable cause) {
+		super(cause);
+	}
+
+	public AFPFormatException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/org.afplib/src/main/java/org/afplib/io/AfpInputStream.java
+++ b/org.afplib/src/main/java/org/afplib/io/AfpInputStream.java
@@ -78,7 +78,7 @@ public class AfpInputStream extends FilterInputStream {
 			    buf = read();
 			    if(buf == -1) return null;
 			    if((buf & 0xff) != 0xd3) {
-		            throw new IOException("cannot find 5a magic byte nor d3 -> this is no AFP");			        
+		            throw new AFPFormatException("cannot find 5a magic byte nor d3 -> this is no AFP");			        
 			    }
 			    offset = 0;
 			}
@@ -100,7 +100,7 @@ public class AfpInputStream extends FilterInputStream {
 		}
 		
 		if(has5a && (buf & 0xff) != 0x5a) {
-			throw new IOException("cannot find 5a magic byte");
+			throw new AFPFormatException("cannot find 5a magic byte");
 		}
 		data[0] = 0x5a; // (byte) (buf & 0xff);
 		
@@ -110,7 +110,7 @@ public class AfpInputStream extends FilterInputStream {
 		}
 		
 		if(buf == -1) {
-			throw new IOException("premature end of file.");
+			throw new AFPFormatException("premature end of file.");
 		}
 		data[1] = (byte) (buf & 0xff);
 
@@ -118,7 +118,7 @@ public class AfpInputStream extends FilterInputStream {
 
 		buf = read(); offset++;
 		if(buf == -1)
-			throw new IOException("premature end of file.");
+			throw new AFPFormatException("premature end of file.");
 		data[2] = (byte) (buf & 0xff);
 
 		length |= (byte) buf & 0xff;
@@ -126,13 +126,13 @@ public class AfpInputStream extends FilterInputStream {
 		length -= 2;
 		
 		if(length > data.length)
-			throw new IOException("length of structured field is too large: "+length);
+			throw new AFPFormatException("length of structured field is too large: "+length);
 				
 		int read = read(data, 3, length);
 		offset += read;
 		
 		if(read < length)
-			throw new IOException("premature end of file.");
+			throw new AFPFormatException("premature end of file.");
 		
 		SF sf = factory.sf(data, 0, getLength() + 2);
 		sf.setLength(length + 3);

--- a/org.afplib/src/main/java/org/afplib/io/AfpMappedFile.java
+++ b/org.afplib/src/main/java/org/afplib/io/AfpMappedFile.java
@@ -46,7 +46,7 @@ public class AfpMappedFile implements Closeable {
 
 		int remaining = afpData.remaining();
 		if(remaining == 0) return null;
-		if(remaining < 9) throw new IOException("trailing garbage at the end of file.");
+		if(remaining < 9) throw new AFPFormatException("trailing garbage at the end of file.");
 		
 		byte buf;
 		long thisOffset = afpData.position();
@@ -69,7 +69,7 @@ public class AfpMappedFile implements Closeable {
 			}
 			
 			if((buf & 0xff) != 0x5a)
-				throw new IOException("cannot find 5a magic byte");
+				throw new AFPFormatException("cannot find 5a magic byte");
 			data[0] = buf;
 			
 			buf = afpData.get();
@@ -83,7 +83,7 @@ public class AfpMappedFile implements Closeable {
 			length -= 2;
 			
 			if(length + 3 > data.length)
-				throw new IOException("length of structured field is too large: "+length);
+				throw new AFPFormatException("length of structured field is too large: "+length);
 					
 			afpData.get(data, 3, length);
 		} catch (BufferUnderflowException e) {

--- a/org.afplib/src/test/java/org/afplib/AfpInputStreamTest.java
+++ b/org.afplib/src/test/java/org/afplib/AfpInputStreamTest.java
@@ -1,8 +1,6 @@
 package org.afplib;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -11,8 +9,10 @@ import org.afplib.afplib.BRS;
 import org.afplib.afplib.ResourceObjectType;
 import org.afplib.base.SF;
 import org.afplib.base.Triplet;
+import org.afplib.io.AFPFormatException;
 import org.afplib.io.AfpInputStream;
 import org.eclipse.emf.common.util.EList;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class AfpInputStreamTest {
@@ -67,4 +67,17 @@ public class AfpInputStreamTest {
 		
 	}
 
+	@Test(expected = AFPFormatException.class) public void testPrematureEndOfFile() throws IOException {
+		String sf = "5A001CD3A8CE000000C6F1C1F1F0F1F1F100000A21FE00";
+		byte[] b = new byte[sf.length()/2];
+		for(int i=0; i<sf.length(); i+=2) {
+			Integer ii = Integer.valueOf(sf.substring(i, i+2), 16);
+			b[i/2] = (byte) ii.intValue();
+		}
+		assertTrue((byte)0xD3 == b[3]);
+		
+		try (AfpInputStream afpin = new AfpInputStream(new ByteArrayInputStream(b))) {
+			afpin.readStructuredField();
+		}
+	}
 }


### PR DESCRIPTION
Hallo, Herr Hackl-Feldbusch,

wie angekündigt mein Vorschlag für eine typisierte Exception bei Formatverletzungen. Wäre schön, wenn Sie ihn so oder in abgewandelter Form berücksichtigen könnten.

Freundliche Grüße
Michael Grübsch