### PR TITLE
Update AfpOutputStream.java

### DIFF
--- a/org.afplib/src/main/java/org/afplib/io/AfpOutputStream.java
+++ b/org.afplib/src/main/java/org/afplib/io/AfpOutputStream.java
@@ -34,6 +34,6 @@ public class AfpOutputStream extends FilterOutputStream {
 		buffer[7] = bIndex[0]; // reserved
 		buffer[8] = bIndex[1]; // reserved
 		
-		write(buffer, 0, length);
+		out.write(buffer, 0, length);
 	}
 }


### PR DESCRIPTION
performance issue with relying on byte per byte FilterOutputStream write operation, as an alternative relying on the OutPutstream write operation fixes our performance issue